### PR TITLE
Day003 Minor updates

### DIFF
--- a/Day003_Hello_Jobs_Part_1/README.md
+++ b/Day003_Hello_Jobs_Part_1/README.md
@@ -145,9 +145,9 @@ We can attach to the Nautobot docker image from the terminal window with ```dock
 Let's attach to the nautobot container as root, navigate to the ```/opt/nautobot/jobs``` folder, then create a ```hello_jobs.py``` file:  
 
 ```
-@ericchou1 ➜ ~ $ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
+@ericchou1 ➜ ~ $ docker exec -it nautobot_docker_compose-nautobot-1 bash
 
-root@196e7f7abedd:/opt/nautobot# cd /opt/nautobot/jobs/
+root@196e7f7abedd:/opt/nautobot# cd jobs
 root@196e7f7abedd:/opt/nautobot/jobs# touch hello_jobs.py
 ```
 


### PR DESCRIPTION
- docker exec drops you into the shell as root by default
- docker exec default working directory is /opt/nautobot, just need `cd jobs`