### PR TITLE
Remove references to creating job thru container

### DIFF
--- a/Day003_Hello_Jobs_Part_1/README.md
+++ b/Day003_Hello_Jobs_Part_1/README.md
@@ -76,10 +76,6 @@ We now have Nautobot running in debug mode with a browser window open to access 
 
 ## Creating the Job File
 
-We are now ready to create our first job file using Python. **There are two options to do this, just pick one.** If you’re new to Nautobot Jobs, which is probably the case for most of us, I’d recommend starting with Option 1. But don’t worry—take a look at Option 2 as well to understand the structure behind it. 
-
-### Option 1. Create File in Jobs Folder
-
 Under ```nautobot-docker-compose``` folder, find the ```jobs``` folder and right click to create a New File and name it ```hello_jobs.py```:
 
 ![create_job_in_folder_1](images/create_job_in_folder_1.png)
@@ -112,76 +108,12 @@ services:
       - "../jobs:/opt/nautobot/jobs"
 ```
 
-If you already created the file via option 1, you can read through option 2 for a better understanding of the jobs file structure. 
-
-### Option 2. Create File in Docker Container
-
-With option 2, we will create the job file directly in the ```nautobot``` container. We want to demonstrate this option because it follows the method used in the [Jobs Developer Guide](https://docs.nautobot.com/projects/core/en/stable/development/jobs/#installing-jobs) for installing jobs.   
-
-Let's come back to the terminal section. While leaving the first ```invoke debug``` window open, click on the ```+``` sign to add a separate terminal window: 
-
-![start_new_terminal_1](images/start_new_terminal_1.png)
-
-
-> [!TIP] 
-> By leaving the first terminal window open and in debug mode, we will be able to see the system level messages that is helpful during our learning process. 
-
-Let's see which docker containers are running: 
-
-```
-@ericchou1 ➜ ~ $ docker ps
-CONTAINER ID   IMAGE                                    COMMAND                  CREATED              STATUS                        PORTS                                                 NAMES
-0674568846da   yourrepo/nautobot-docker-compose:local   "sh -c 'nautobot-ser…"   About a minute ago   Up About a minute (healthy)   8080/tcp, 8443/tcp                                    nautobot_docker_compose-celery_worker-1
-50c2738fbded   yourrepo/nautobot-docker-compose:local   "sh -c 'nautobot-ser…"   About a minute ago   Up About a minute             8080/tcp, 8443/tcp                                    nautobot_docker_compose-celery_beat-1
-15a80b83b587   yourrepo/nautobot-docker-compose:local   "/docker-entrypoint.…"   About a minute ago   Up About a minute (healthy)   0.0.0.0:8080->8080/tcp, :::8080->8080/tcp, 8443/tcp   nautobot_docker_compose-nautobot-1
-fd292402488a   redis:6-alpine                           "docker-entrypoint.s…"   About a minute ago   Up About a minute             6379/tcp                                              nautobot_docker_compose-redis-1
-5075768319ae   postgres:13-alpine                       "docker-entrypoint.s…"   About a minute ago   Up About a minute (healthy)   5432/tcp                                              nautobot_docker_compose-db-1
-@ericchou1 ➜ ~ $ 
-
-```
-
-We can attach to the Nautobot docker image from the terminal window with ```docker exec```. 
-
-Let's attach to the nautobot container as root, navigate to the ```/opt/nautobot/jobs``` folder, then create a ```hello_jobs.py``` file:  
-
-```
-@ericchou1 ➜ ~ $ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
-
-root@196e7f7abedd:/opt/nautobot# cd /opt/nautobot/jobs/
-root@196e7f7abedd:/opt/nautobot/jobs# touch hello_jobs.py
-```
-
 > [!IMPORTANT] 
-> The location of the file is very important, this is where Nautobot looks for the job files. Also the file permission with `chown` is critical as well. 
-
-We will need to change the owner and group for the file to `nautobot`: 
-
-```
-root@196e7f7abedd:/opt/nautobot/jobs# ls -lia hello_jobs.py 
-1487781 -rw-r--r-- 1 root root 0 Oct 17 12:38 hello_jobs.py
-
-root@196e7f7abedd:/opt/nautobot/jobs# chown nautobot:nautobot hello_jobs.py 
-
-root@196e7f7abedd:/opt/nautobot/jobs# ls -lia hello_jobs.py 
-
-1487781 -rw-r--r-- 1 nautobot nautobot 0 Oct 17 12:38 hello_jobs.py
-```
-
-We can edit the file directly in the terminal. However, remember that Visual Studio Code is a full-featured IDE. By using the Docker extension, we can make edits much more intuitively.
-
-We can click on the docker extension symbol and find the Nautobot container: 
-
-![docker_access_1](images/docker_access_1.png)
-
-Once we locate the file under `/opt/nautobot/jobs`, highlight it and choose the `open` option to open in the viewer area: 
-
-![docker_access_2](images/docker_access_2.png)
-
-Once we have the file open, we can start adding components to the job. 
+> The location and file permissions of the file is very important, this is where Nautobot ingests job files. 
 
 ## Hello Jobs
 
-Whether you used Option 1 or Option 2, you are now ready to modify the Python file to specify the details of the job.
+You are now ready to modify the Python file to specify the details of the job.
 
 First, we'll have to import the necessary object and methods from the ```nautobot.apps.jobs``` module: 
 

--- a/Day006_Object_as_Variables/README.md
+++ b/Day006_Object_as_Variables/README.md
@@ -32,28 +32,9 @@ Let's create a file for today's challenge. We can either do this via the shared 
 > [!TIP]
 > Take a look at [Day 003 Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md) if you need a refresher. 
 
-Let's begin by creating a file named `Day6_Variable_Example` on the Nautobot docker container under the `/opt/nautobot/jobs` directory (please feel free to create it via the shared directory if you'd prefer): 
+Let's begin by creating a file named `Day6_Variable_Example.py` under `nautobot-docker-compose/jobs` in the VSCode editor. This is further explored in the [Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md)) lab.
 
-1. Create the file under `/opt/nautobot/jobs`.
-2. Change the file ownership to `nautobot:nautobot`.
-
-```
-(nautobot-docker-compose-py3.10) @ericchou1 ➜ ~/nautobot-docker-compose (main) $ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
-
-root@32a27fa1f5a6:/opt/nautobot# cd jobs
-root@32a27fa1f5a6:/opt/nautobot/jobs# touch Day6_Variable_Example.py
-
-root@32a27fa1f5a6:/opt/nautobot/jobs# chown nautobot:nautobot Day6_Variable_Example.py 
-
-root@32a27fa1f5a6:/opt/nautobot/jobs# ls -lia Day6_Variable_Example.py 
-1618584 -rw-r--r-- 1 nautobot nautobot 0 Nov 10 15:07 Day6_Variable_Example.py
-```
-
-We can right-click on the file to edit it in the main window: 
-
-![file_edit](images/file_edit.png)
-
-Let's pick up where `HelloJobs.py` left off and fill in some boilerplate code to see the job show up in our UI: 
+Let's pick up where `HelloJobs.py` left off and fill in some boilerplate code to see the job show up in our UI:
 
 ```python
 from nautobot.apps.jobs import MultiChoiceVar, Job, ObjectVar, register_jobs, TextVar, IntegerVar

--- a/Day007_Data_Quality_Jobs_Part_1/README.md
+++ b/Day007_Data_Quality_Jobs_Part_1/README.md
@@ -22,17 +22,7 @@ We are ready to create our new job file.
 
 ## Job File Creation 
 
-Let's create a new job named `data_quality_jobs.py` under `/opt/nautobot/jobs` in the nautobot docker container (feel free to use Option 1 as specified in [Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md)): 
-
-```
-(nautobot-docker-compose-py3.10) @ericchou1 ➜ ~/nautobot-docker-compose (main) $ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
-
-root@32a27fa1f5a6:/opt/nautobot# cd jobs
-
-root@32a27fa1f5a6:/opt/nautobot/jobs# touch data_quality_jobs.py
-
-root@32a27fa1f5a6:/opt/nautobot/jobs# chown nautobot:nautobot data_quality_jobs.py
-```
+Let's create a new job named `data_quality_jobs.py` under `nautobot-docker-compose/jobs` in the VSCode editor. This is further explored in the [Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md) lab.
 
 We will use this file to work on the rest of today's challenge. 
 

--- a/Day008_Data_Quality_Jobs_Part_2/README.md
+++ b/Day008_Data_Quality_Jobs_Part_2/README.md
@@ -12,16 +12,7 @@ In today's job, we will build from Day 007's data quality job. The main learning
 > $ invoke debug
 > ```
 
-As a reminder, in Day 007 we created a file named ```data_quality_jobs.py``` under ```/opt/nautobot/jobs``` in the nautobot docker container. Here is a repeat of [Day 7](../Day007_Data_Quality_Jobs_Part_1/README.md) file creation and file content: 
-
-```
-(nautobot-docker-compose-py3.10) @ericchou1 ➜ ~/nautobot-docker-compose (main) $ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
-
-root@32a27fa1f5a6:/opt/nautobot/jobs# touch data_quality_jobs.py
-root@32a27fa1f5a6:/opt/nautobot/jobs# chown nautobot:nautobot data_quality_jobs.py
-```
-
-Let's go ahead and paste in the code where we left off from Day 007: 
+As a reminder, in Day 007 we created a file named ```data_quality_jobs.py``` under ```nautobot-docker-compose/jobs```. Additional guidance on this file creation process is explored in the [Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md)) lab. Here is a repeat of [Day 7's](../Day007_Data_Quality_Jobs_Part_1/README.md) file content:
 
 ```python
 from nautobot.apps.jobs import MultiChoiceVar, Job, ObjectVar, register_jobs, StringVar, IntegerVar

--- a/Day009_Python_Script_to_Jobs_Part_1/README.md
+++ b/Day009_Python_Script_to_Jobs_Part_1/README.md
@@ -9,7 +9,7 @@ In many of the future challenges, we will need to have a network lab our Nautobo
 
 ![codespace_machine_types](images/codespace_machine_types.png)
 
-Again, as we stated in the `warnign` box above, s we add more containers to the Codespace environment, you will find the CPU running high during the launch. I have successfully completed the lab with the `2-core` machine types, but I had to wait a while for the CPU to normalize. 
+Again, as we stated in the `warning` box above, as we add more containers to the Codespace environment, you will find the CPU running high during the launch. I have successfully completed the lab with the `2-core` machine types, but I had to wait a while for the CPU to normalize. 
 
 ## Lab Environment Setup
 

--- a/Day010_Python_Script_to_Jobs_Part_2/README.md
+++ b/Day010_Python_Script_to_Jobs_Part_2/README.md
@@ -32,20 +32,7 @@ Let's create the file needed for today's challenge.
 
 ## Operations Job File
 
-We will create a file named ```operation_jobs.py``` under the ```/opt/nautobot/jobs``` folder on the Nautobot docker instance: 
-
-```
-$ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
-root@c9e0fa2a45a0:/opt/nautobot# cd jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# pwd
-/opt/nautobot/jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# touch operation_jobs.py
-root@c9e0fa2a45a0:/opt/nautobot/jobs# chown nautobot:nautobot operation_jobs.py
-```
-
-Once the file is created, we can open it on the main panel and start to work on it: 
-
-![operation_jobs_file_1](images/operation_jobs_file_1.png)
+Let's create a new job named ```operation_jobs.py``` under ```nautobot-docker-compose/jobs``` in the VSCode editor. This is further explored in the [Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md) lab.
 
 We will build this job step-by-step. 
 

--- a/Day011_ChangeVLAN/README.md
+++ b/Day011_ChangeVLAN/README.md
@@ -43,18 +43,7 @@ $ cd clab/
 $ sudo containerlab deploy --topo ceos-lab.clab.yml --node-filter bos-acc-01,bos-rtr-01
 ```
 
-Let's create a file for today's challenge. We can either do this via the shared directory or directly in the Nautobot docker container: 
-
-```
-$ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
-root@c9e0fa2a45a0:/opt/nautobot# cd jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# pwd
-/opt/nautobot/jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# touch operation_jobs.py
-root@c9e0fa2a45a0:/opt/nautobot/jobs# chown nautobot:nautobot operation_jobs.py
-```
-
-The environment is now setup for today's challenge.  
+Let's create a new job named `operation_jobs.py` under `nautobot-docker-compose/jobs` in the VSCode editor. This is further explored in the [Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md) lab.
 
 > [!NOTE]
 > Today's challenge is an extension of Day 10's challenge, please feel free to copy and paste the final version of Day 10's Job before continuing.  
@@ -78,7 +67,7 @@ from nautobot.ipam.models import VLAN
 from nautobot.apps.jobs import JobButtonReceiver
 ```
 
-We will use the special global variable ```name``` to indicate the name of the Jobs: 
+We will use the special global variable ```name``` to indicate the name of the Jobs:
 
 ```
 name = "Network Operations"

--- a/Day012_Job_Button/README.md
+++ b/Day012_Job_Button/README.md
@@ -43,20 +43,7 @@ $ cd clab/
 $ sudo containerlab deploy --topo ceos-lab.clab.yml --node-filter bos-acc-01,bos-rtr-01
 ```
 
-Let's create a file for today's challenge. We can either do this via the shared directory or directly in the Nautobot docker container: 
-
-![file_creation.png](images/file_creation.png)
-
-```
-$ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
-root@c9e0fa2a45a0:/opt/nautobot# cd jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# pwd
-/opt/nautobot/jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# touch hello_world_job_button.py
-root@c9e0fa2a45a0:/opt/nautobot/jobs# chown nautobot:nautobot hello_world_job_button.py
-```
-
-The environment is now setup for today's challenge.  
+Let's create a new job named `hello_world_job_button.py` under `nautobot-docker-compose/jobs` in the VSCode editor. This is further explored in the [Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md) lab.
 
 ## First Job Button Receiver 
 

--- a/Day013_Bounce_Interface_Port_with_Job_Button/README.md
+++ b/Day013_Bounce_Interface_Port_with_Job_Button/README.md
@@ -34,20 +34,7 @@ $ cd clab/
 $ sudo containerlab deploy --topo ceos-lab.clab.yml --node-filter bos-acc-01,bos-rtr-01
 ```
 
-Let's create a file for today's challenge. We can either do this via the shared directory or directly in the Nautobot docker container, we will name this file `port_bounce_job_button.py`: 
-
-![file_creation](images/file_creation.png)
-
-```
-$ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
-root@c9e0fa2a45a0:/opt/nautobot# cd jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# pwd
-/opt/nautobot/jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# touch port_bounce_job_button.py
-root@c9e0fa2a45a0:/opt/nautobot/jobs# chown nautobot:nautobot port_bounce_job_button.py
-```
-
-The environment is now setup for today's challenge.  
+Let's create a new job named `port_bounce_job_button.py` under `nautobot-docker-compose/jobs` in the VSCode editor. This is further explored in the [Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md) lab.
 
 ## Job Button Receiver
 

--- a/Day014_Job_Hooks/README.md
+++ b/Day014_Job_Hooks/README.md
@@ -23,20 +23,7 @@ $ invoke debug
 
 We do not need to use Containerlab for this challenge. 
 
-Let's create a file for today's challenge. We can either do this via the shared directory or directly in the Nautobot docker container: 
-
-![file_creation](images/file_creation.png)
-
-```
-$ docker exec -u root -it nautobot_docker_compose-nautobot-1 bash
-root@c9e0fa2a45a0:/opt/nautobot# cd jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# pwd
-/opt/nautobot/jobs
-root@c9e0fa2a45a0:/opt/nautobot/jobs# touch job_hook_test.py
-root@c9e0fa2a45a0:/opt/nautobot/jobs# chown nautobot:nautobot ob_hook_test.py
-```
-
-The environment is now setup for today's challenge.  
+Let's create a new job named `ob_hook_test.py` under `nautobot-docker-compose/jobs` in the VSCode editor. This is further explored in the [Hello Jobs](../Day003_Hello_Jobs_Part_1/README.md) lab.
 
 ## Job Hook Receiver
 


### PR DESCRIPTION
Fixes #9 

This PR updates the directions of several labs to drop references to manipulating the files through docker and instead rely on VS Code. This came up from several users in our slack forum who called out that they were receiving permissions errors when attempting to manipulate the jobs files via docker.