### PR TITLE
docs: fix Day 12 / 16 / 17 README typos

### DIFF
--- a/Day012_Job_Button/README.md
+++ b/Day012_Job_Button/README.md
@@ -101,7 +101,7 @@ We are ready to wire this job receiver with an object.
 
 ## Wire Up the Job Receiver
 
-By default, Job button receivers are not visible on the Job UO, We will need to click on the filter button on the Job menu: 
+By default, Job button receivers are not visible on the Job UI, we will need to click on the filter button on the Job menu: 
 
 ![job_button_3](images/job_button_3.png)
 

--- a/Day016_Job_Scheduling/README.md
+++ b/Day016_Job_Scheduling/README.md
@@ -68,7 +68,7 @@ Once the job is scheduled, it can be viewed under 'Jobs -> Scheduled Jobs":
 
 ![job_scheduling_4](images/job_schedule_4.png)
 
-Job scheduling is a simple but powerful feature, if you have some time, experiment with the existing 'System Jobs' for 'Logs Cleanup' or take a look at the [Nautobot Golden Config App](https://docs.nautobot.com/projects/golden-config/en/latest/), where job schedule is used for configuration back. 
+Job scheduling is a simple but powerful feature, if you have some time, experiment with the existing 'System Jobs' for 'Logs Cleanup' or take a look at the [Nautobot Golden Config App](https://docs.nautobot.com/projects/golden-config/en/latest/), where job schedule is used for configuration backup. 
 
 ## Day 16 To Do
 

--- a/Day017_Job_Approvals/README.md
+++ b/Day017_Job_Approvals/README.md
@@ -49,7 +49,7 @@ The property for `approval required` can be set in the `properties` section:
 
 ![job_approval_2](images/job_approval_2.png)
 
-Once the properties is changed, the `Run Job Now` will be changed to `Reqeust to Run Job Now`: 
+Once the properties is changed, the `Run Job Now` will be changed to `Request to Run Job Now`: 
 
 ![job_approval_3](images/job_approval_3.png)
 


### PR DESCRIPTION
Three prose typos flagged in separate issues; fixed in one pass:

* `Day017_Job_Approvals/README.md`: `Reqeust` → `Request` (#70)
* `Day016_Job_Scheduling/README.md`: `configuration back` → `configuration backup` (#69)
* `Day012_Job_Button/README.md`: `Job UO` → `Job UI` (#68; also lowercased the following `We` so the comma doesn't start a new sentence)

Closes #68, #69, #70.