### PR TITLE
docs: surface Nautobot 3.1 Upgrade Lab from top-level README and Day 100

### DIFF
--- a/Day100_Final_Thoughts/README.md
+++ b/Day100_Final_Thoughts/README.md
@@ -25,6 +25,10 @@ This journey has been a comprehensive exploration of Nautobot's capabilities, be
 
 Your journey with Nautobot doesn't end here. Here are some suggestions for continuing your growth and contribution to the Nautobot community:
 
+### Move to Nautobot 3.1
+
+The main 100 Days target Nautobot 2.x. If you want to bring your environment forward to the version currently running [demo.nautobot.com](https://demo.nautobot.com/), the [Nautobot 3.1 Upgrade Lab](../Nautobot_3_1_Upgrade_Lab/README.md) is a two-day expansion pack that walks an in-place 2.3.2 → 3.1.2 upgrade and catalogs the differences you will notice when replaying earlier Days against the upgraded environment.
+
 ### Continued Learning
 
 1. **Advanced Topics**: Explore advanced topics such as custom plugins, integrations, and scaling Nautobot for large environments.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Making a public commitment increases social accountability and provide network o
 
 I am glad you asked, sign up for the challenge [here](https://go.networktocode.com/100-days-of-nautobot) if you have not done so already, and let the games begin! 
 
+## Expansion Packs
+
+In addition to the main 100 Days, we maintain **expansion packs** — short, focused labs that cover topics adjacent to the core challenge.
+
+- **[Nautobot 3.1 Upgrade Lab](Nautobot_3_1_Upgrade_Lab/README.md)** — a two-day lab that walks an in-place upgrade of the Scenario 1 environment from Nautobot 2.3.2 to 3.1.2 (the version on [demo.nautobot.com](https://demo.nautobot.com/)), followed by a reference for what looks different in 3.1 when replaying Days 1–100 against the upgraded environment.
+
+More expansion packs are planned, including coverage of popular Nautobot apps that the main 100 Days do not get to.
+
 ## Contributors
 
 This repository is a team effort, thank you for making this challenge happen. 


### PR DESCRIPTION
Adds an "Expansion Packs" section to the top-level README and a "Move to Nautobot 3.1" sub-section to Day 100's Next Steps so learners can find the new Nautobot_3_1_Upgrade_Lab/ from the main entry points.