### PR TITLE
Fix Day 009 README.md

### DIFF
--- a/Day009_Python_Script_to_Jobs_Part_1/README.md
+++ b/Day009_Python_Script_to_Jobs_Part_1/README.md
@@ -49,7 +49,7 @@ As part of our setup, the Containerlab executables have already been installed. 
        date: 2024-09-21T12:26:37Z
      source: https://github.com/srl-labs/containerlab
  rel. notes: https://containerlab.dev/rn/0.57/#0573
- ```
+```
 
 In the next step, we will download the Arista cEOS image to be used in our lab. 
 


### PR DESCRIPTION
Hey there,

Minor typo on Day 009.

In the end of the code block for container lab text, the closing code block has a space which causes it to render like so in general markdown viewers
<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/63ef8a6c-58eb-408c-bd30-2476fdb0ab2f" />


With the space removed it correctly renders
<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/0ba8101b-3391-4b55-9a3f-f82b34efc3f0" />
